### PR TITLE
[FIX] gsm module doesn't work on Micropython example.

### DIFF
--- a/examples/MicroPython_LoBo/main.py
+++ b/examples/MicroPython_LoBo/main.py
@@ -27,9 +27,11 @@ GSM_PASS = '' # Your Pass
 
 GSM_PWR = machine.Pin(4, machine.Pin.OUT)
 GSM_RST = machine.Pin(5, machine.Pin.OUT)
+GSM_MODEM_PWR = machine.Pin(23, machine.Pin.OUT)
 
 GSM_PWR.value(0)
 GSM_RST.value(1)
+GSM_MODEM_PWR.value(1)
 
 # Init PPPoS
 


### PR DESCRIPTION
This issue cause by the missing config pin for SIM800_POWER which is pin
23 on example file. And this commit will fix this issue.

[This issue will be resolved](https://github.com/Xinyuan-LilyGO/TTGO-T-Call/issues/16)